### PR TITLE
feat: Google Calendar-style month/week views

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -7,8 +7,16 @@ import { ModuleHeader } from "@/components/layout/ModuleHeader";
 import { Card } from "@/components/ui/Card";
 import { MonthNavigation } from "@/components/calendar/MonthNavigation";
 import { MonthGrid } from "@/components/calendar/MonthGrid";
+import { WeekView } from "@/components/calendar/WeekView";
 import { DayDetail } from "@/components/calendar/DayDetail";
-import { buildMonthGrid, groupEventsByDate, navigateMonth } from "@/lib/utils/calendar";
+import {
+  buildMonthGrid,
+  buildWeekGrid,
+  groupEventsByDate,
+  navigateMonth,
+  navigateWeek,
+} from "@/lib/utils/calendar";
+import type { CalendarViewMode } from "@/lib/utils/calendar";
 import { Calendar, LogIn } from "lucide-react";
 import type { CalendarEvent } from "@/types";
 
@@ -18,21 +26,27 @@ export default function CalendarPage() {
   const { data: session, status } = useSession();
   const now = new Date();
 
+  const [viewMode, setViewMode] = useState<CalendarViewMode>("month");
   const [currentYear, setCurrentYear] = useState(now.getFullYear());
   const [currentMonth, setCurrentMonth] = useState(now.getMonth());
+  const [currentDay, setCurrentDay] = useState(now.getDate());
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
-  const isCurrentMonth =
-    currentYear === now.getFullYear() && currentMonth === now.getMonth();
-
-  const grid = useMemo(
+  const monthGrid = useMemo(
     () => buildMonthGrid(currentYear, currentMonth),
     [currentYear, currentMonth]
   );
 
+  const weekGrid = useMemo(
+    () => buildWeekGrid(currentYear, currentMonth, currentDay),
+    [currentYear, currentMonth, currentDay]
+  );
+
+  const activeGrid = viewMode === "month" ? monthGrid : weekGrid;
+
   const { data: events = [], isLoading } = useSWR<CalendarEvent[]>(
     session?.user
-      ? `/api/calendar?timeMin=${encodeURIComponent(grid.gridStart)}&timeMax=${encodeURIComponent(grid.gridEnd)}`
+      ? `/api/calendar?timeMin=${encodeURIComponent(activeGrid.gridStart)}&timeMax=${encodeURIComponent(activeGrid.gridEnd)}`
       : null,
     fetcher,
     { refreshInterval: 5 * 60 * 1000 }
@@ -42,16 +56,37 @@ export default function CalendarPage() {
 
   const isGuest = status !== "loading" && !session?.user;
 
+  const isCurrentPeriod =
+    viewMode === "month"
+      ? currentYear === now.getFullYear() && currentMonth === now.getMonth()
+      : weekGrid.days.some((d) => d.isToday);
+
+  const label = viewMode === "month" ? monthGrid.label : weekGrid.label;
+
   const handleNavigate = (delta: number) => {
-    const next = navigateMonth(currentYear, currentMonth, delta);
-    setCurrentYear(next.year);
-    setCurrentMonth(next.month);
+    if (viewMode === "month") {
+      const next = navigateMonth(currentYear, currentMonth, delta);
+      setCurrentYear(next.year);
+      setCurrentMonth(next.month);
+    } else {
+      const next = navigateWeek(currentYear, currentMonth, currentDay, delta);
+      setCurrentYear(next.year);
+      setCurrentMonth(next.month);
+      setCurrentDay(next.day);
+    }
     setSelectedDate(null);
   };
 
   const handleToday = () => {
-    setCurrentYear(now.getFullYear());
-    setCurrentMonth(now.getMonth());
+    const n = new Date();
+    setCurrentYear(n.getFullYear());
+    setCurrentMonth(n.getMonth());
+    setCurrentDay(n.getDate());
+    setSelectedDate(null);
+  };
+
+  const handleViewChange = (mode: CalendarViewMode) => {
+    setViewMode(mode);
     setSelectedDate(null);
   };
 
@@ -77,11 +112,13 @@ export default function CalendarPage() {
       ) : (
         <>
           <MonthNavigation
-            label={grid.label}
-            isCurrentMonth={isCurrentMonth}
+            label={label}
+            isCurrentPeriod={isCurrentPeriod}
+            viewMode={viewMode}
             onPrev={() => handleNavigate(-1)}
             onNext={() => handleNavigate(1)}
             onToday={handleToday}
+            onViewChange={handleViewChange}
           />
 
           {isLoading && events.length === 0 ? (
@@ -90,9 +127,16 @@ export default function CalendarPage() {
                 Loading events...
               </div>
             </Card>
-          ) : (
+          ) : viewMode === "month" ? (
             <MonthGrid
-              days={grid.days}
+              days={monthGrid.days}
+              eventsByDate={eventsByDate}
+              selectedDate={selectedDate}
+              onSelectDate={setSelectedDate}
+            />
+          ) : (
+            <WeekView
+              days={weekGrid.days}
               eventsByDate={eventsByDate}
               selectedDate={selectedDate}
               onSelectDate={setSelectedDate}

--- a/src/components/calendar/MonthGrid.tsx
+++ b/src/components/calendar/MonthGrid.tsx
@@ -1,16 +1,40 @@
 "use client";
 
 import { Card } from "@/components/ui/Card";
+import { sortEventsForCell } from "@/lib/utils/calendar";
+import { formatTimeShort } from "@/lib/utils/dates";
 import type { CalendarDay } from "@/lib/utils/calendar";
 import type { CalendarEvent } from "@/types";
 
 const DAY_HEADERS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MAX_VISIBLE = 3;
 
 interface MonthGridProps {
   days: CalendarDay[];
   eventsByDate: Map<string, CalendarEvent[]>;
   selectedDate: string | null;
   onSelectDate: (dateKey: string) => void;
+}
+
+function EventChip({ event, isAllDay }: { event: CalendarEvent; isAllDay: boolean }) {
+  const label = isAllDay
+    ? event.summary
+    : `${formatTimeShort(event.start)} ${event.summary}`;
+
+  return (
+    <div
+      className={`
+        text-[10px] leading-tight px-1 py-0.5 rounded truncate w-full
+        ${isAllDay
+          ? "bg-blue-400/20 text-blue-300"
+          : "bg-accent/15 text-accent"
+        }
+      `}
+      title={event.summary}
+    >
+      {label}
+    </div>
+  );
 }
 
 export function MonthGrid({
@@ -39,14 +63,18 @@ export function MonthGrid({
           const events = eventsByDate.get(day.dateKey) || [];
           const isSelected = selectedDate === day.dateKey;
           const eventCount = events.length;
+          const { allDay, timed } = sortEventsForCell(events);
+          const allEvents = [...allDay, ...timed];
+          const visible = allEvents.slice(0, MAX_VISIBLE);
+          const overflow = allEvents.length - MAX_VISIBLE;
 
           return (
             <button
               key={day.dateKey}
               onClick={() => onSelectDate(day.dateKey)}
               className={`
-                relative min-h-12 md:min-h-16 p-1 flex flex-col items-center gap-0.5
-                border-b border-r border-border/30 transition-colors
+                relative min-h-14 md:min-h-24 p-1 flex flex-col items-start
+                border-b border-r border-border/30 transition-colors text-left
                 ${day.isCurrentMonth ? "" : "opacity-30"}
                 ${day.isToday && isSelected
                   ? "bg-accent/20 ring-1 ring-inset ring-accent"
@@ -59,7 +87,7 @@ export function MonthGrid({
               `}
             >
               <span
-                className={`text-sm leading-none mt-1 ${
+                className={`text-xs leading-none ${
                   day.isToday
                     ? "text-accent font-semibold"
                     : day.isCurrentMonth
@@ -70,9 +98,9 @@ export function MonthGrid({
                 {day.dayOfMonth}
               </span>
 
-              {/* Event indicators */}
+              {/* Mobile: dots */}
               {eventCount > 0 && (
-                <div className="flex items-center gap-0.5 mt-0.5">
+                <div className="flex items-center gap-0.5 mt-1 md:hidden">
                   {eventCount <= 3 ? (
                     Array.from({ length: eventCount }).map((_, i) => (
                       <div
@@ -83,6 +111,24 @@ export function MonthGrid({
                   ) : (
                     <span className="text-[9px] text-accent font-medium">
                       {eventCount}
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {/* Desktop: event chips */}
+              {eventCount > 0 && (
+                <div className="hidden md:flex flex-col gap-0.5 w-full mt-1 overflow-hidden flex-1">
+                  {visible.map((event) => (
+                    <EventChip
+                      key={event.id}
+                      event={event}
+                      isAllDay={!event.start.includes("T")}
+                    />
+                  ))}
+                  {overflow > 0 && (
+                    <span className="text-[9px] text-muted px-1">
+                      +{overflow} more
                     </span>
                   )}
                 </div>

--- a/src/components/calendar/MonthNavigation.tsx
+++ b/src/components/calendar/MonthNavigation.tsx
@@ -2,38 +2,70 @@
 
 import { Button } from "@/components/ui/Button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { CalendarViewMode } from "@/lib/utils/calendar";
 
 interface MonthNavigationProps {
-  label: string; // "February 2026"
-  isCurrentMonth: boolean;
+  label: string;
+  isCurrentPeriod: boolean;
+  viewMode: CalendarViewMode;
   onPrev: () => void;
   onNext: () => void;
   onToday: () => void;
+  onViewChange: (mode: CalendarViewMode) => void;
 }
 
 export function MonthNavigation({
   label,
-  isCurrentMonth,
+  isCurrentPeriod,
+  viewMode,
   onPrev,
   onNext,
   onToday,
+  onViewChange,
 }: MonthNavigationProps) {
   return (
-    <div className="flex items-center justify-between mb-4">
-      <div className="flex items-center gap-1">
+    <div className="flex items-center justify-between mb-4 gap-2">
+      <div className="flex items-center gap-1 min-w-0">
         <Button variant="ghost" size="sm" onClick={onPrev}>
           <ChevronLeft className="w-4 h-4" />
         </Button>
         <Button variant="ghost" size="sm" onClick={onNext}>
           <ChevronRight className="w-4 h-4" />
         </Button>
-        <h2 className="text-lg font-semibold ml-2">{label}</h2>
+        <h2 className="text-base md:text-lg font-semibold ml-2 truncate">{label}</h2>
       </div>
-      {!isCurrentMonth && (
-        <Button variant="secondary" size="sm" onClick={onToday}>
-          Today
-        </Button>
-      )}
+
+      <div className="flex items-center gap-2 shrink-0">
+        {!isCurrentPeriod && (
+          <Button variant="secondary" size="sm" onClick={onToday}>
+            Today
+          </Button>
+        )}
+
+        {/* View toggle */}
+        <div className="flex rounded-lg border border-border overflow-hidden">
+          <button
+            onClick={() => onViewChange("month")}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+              viewMode === "month"
+                ? "bg-accent text-background"
+                : "text-muted hover:text-foreground hover:bg-surface-hover"
+            }`}
+          >
+            Month
+          </button>
+          <button
+            onClick={() => onViewChange("week")}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors border-l border-border ${
+              viewMode === "week"
+                ? "bg-accent text-background"
+                : "text-muted hover:text-foreground hover:bg-surface-hover"
+            }`}
+          >
+            Week
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { Card } from "@/components/ui/Card";
+import { sortEventsForCell, getEventTopAndHeight } from "@/lib/utils/calendar";
+import { formatTimeShort } from "@/lib/utils/dates";
+import type { CalendarDay } from "@/lib/utils/calendar";
+import type { CalendarEvent } from "@/types";
+
+const DAY_HEADERS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const START_HOUR = 7;
+const END_HOUR = 22;
+const HOUR_HEIGHT = 60; // px per hour
+const HOURS = Array.from({ length: END_HOUR - START_HOUR }, (_, i) => START_HOUR + i);
+
+interface WeekViewProps {
+  days: CalendarDay[];
+  eventsByDate: Map<string, CalendarEvent[]>;
+  selectedDate: string | null;
+  onSelectDate: (dateKey: string) => void;
+}
+
+function formatHourLabel(hour: number): string {
+  const h12 = hour % 12 || 12;
+  const period = hour < 12 ? "AM" : "PM";
+  return `${h12} ${period}`;
+}
+
+export function WeekView({
+  days,
+  eventsByDate,
+  selectedDate,
+  onSelectDate,
+}: WeekViewProps) {
+  const now = new Date();
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  const totalMinutes = (END_HOUR - START_HOUR) * 60;
+  const nowPercent = ((nowMinutes - START_HOUR * 60) / totalMinutes) * 100;
+
+  return (
+    <Card className="p-0 overflow-hidden">
+      {/* Day headers */}
+      <div className="grid grid-cols-[3rem_repeat(7,1fr)] border-b border-border">
+        <div />
+        {days.map((day) => (
+          <button
+            key={day.dateKey}
+            onClick={() => onSelectDate(day.dateKey)}
+            className={`
+              py-2 text-center border-l border-border/30 transition-colors
+              ${selectedDate === day.dateKey ? "bg-surface-hover" : "hover:bg-white/[0.03]"}
+            `}
+          >
+            <div className="text-[10px] text-muted uppercase">
+              {DAY_HEADERS[day.date.getDay()]}
+            </div>
+            <div
+              className={`text-sm font-medium mt-0.5 ${
+                day.isToday
+                  ? "w-7 h-7 rounded-full bg-accent text-background flex items-center justify-center mx-auto"
+                  : ""
+              }`}
+            >
+              {day.dayOfMonth}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* All-day events row */}
+      <div className="grid grid-cols-[3rem_repeat(7,1fr)] border-b border-border">
+        <div className="text-[9px] text-muted py-1 text-right pr-2 self-center">
+          all-day
+        </div>
+        {days.map((day) => {
+          const { allDay } = sortEventsForCell(
+            eventsByDate.get(day.dateKey) || []
+          );
+          return (
+            <div
+              key={day.dateKey}
+              className="border-l border-border/30 p-0.5 min-h-7 flex flex-col gap-0.5"
+            >
+              {allDay.map((e) => (
+                <div
+                  key={e.id}
+                  className="text-[10px] bg-blue-400/20 text-blue-300 px-1 py-0.5 rounded truncate cursor-pointer hover:bg-blue-400/30 transition-colors"
+                  onClick={() => onSelectDate(day.dateKey)}
+                  title={e.summary}
+                >
+                  {e.summary}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Time grid */}
+      <div className="overflow-y-auto max-h-[calc(100vh-18rem)]">
+        <div
+          className="grid grid-cols-[3rem_repeat(7,1fr)] relative"
+          style={{ height: `${HOURS.length * HOUR_HEIGHT}px` }}
+        >
+          {/* Time gutter */}
+          <div className="relative border-r border-border/30">
+            {HOURS.map((hour) => (
+              <div
+                key={hour}
+                className="absolute right-2 text-[10px] text-muted -translate-y-1/2"
+                style={{ top: `${(hour - START_HOUR) * HOUR_HEIGHT}px` }}
+              >
+                {formatHourLabel(hour)}
+              </div>
+            ))}
+          </div>
+
+          {/* Day columns */}
+          {days.map((day) => {
+            const { timed } = sortEventsForCell(
+              eventsByDate.get(day.dateKey) || []
+            );
+            const isSelected = selectedDate === day.dateKey;
+
+            return (
+              <div
+                key={day.dateKey}
+                className={`relative border-l border-border/30 ${
+                  isSelected ? "bg-surface-hover/50" : ""
+                }`}
+                onClick={() => onSelectDate(day.dateKey)}
+              >
+                {/* Hour grid lines */}
+                {HOURS.map((hour) => (
+                  <div
+                    key={hour}
+                    className="absolute left-0 right-0 border-t border-border/15"
+                    style={{ top: `${(hour - START_HOUR) * HOUR_HEIGHT}px` }}
+                  />
+                ))}
+
+                {/* Half-hour grid lines */}
+                {HOURS.map((hour) => (
+                  <div
+                    key={`half-${hour}`}
+                    className="absolute left-0 right-0 border-t border-border/8"
+                    style={{ top: `${(hour - START_HOUR) * HOUR_HEIGHT + HOUR_HEIGHT / 2}px` }}
+                  />
+                ))}
+
+                {/* Current time indicator */}
+                {day.isToday && nowPercent >= 0 && nowPercent <= 100 && (
+                  <div
+                    className="absolute left-0 right-0 z-10 pointer-events-none"
+                    style={{ top: `${nowPercent}%` }}
+                  >
+                    <div className="flex items-center">
+                      <div className="w-2 h-2 rounded-full bg-danger -ml-1 shrink-0" />
+                      <div className="flex-1 border-t-2 border-danger" />
+                    </div>
+                  </div>
+                )}
+
+                {/* Event blocks */}
+                {timed.map((event) => {
+                  const { topPercent, heightPercent } = getEventTopAndHeight(
+                    event,
+                    START_HOUR,
+                    END_HOUR
+                  );
+                  return (
+                    <div
+                      key={event.id}
+                      className="absolute left-0.5 right-0.5 bg-accent/20 border-l-2 border-accent rounded-sm px-1.5 py-0.5 overflow-hidden cursor-pointer hover:bg-accent/30 transition-colors z-[1]"
+                      style={{
+                        top: `${topPercent}%`,
+                        height: `${Math.max(heightPercent, 2.5)}%`,
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onSelectDate(day.dateKey);
+                      }}
+                      title={event.summary}
+                    >
+                      <div className="text-[10px] font-medium text-accent truncate">
+                        {event.summary}
+                      </div>
+                      {heightPercent > 4 && (
+                        <div className="text-[9px] text-accent/70">
+                          {formatTimeShort(event.start)}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/lib/utils/calendar.ts
+++ b/src/lib/utils/calendar.ts
@@ -81,6 +81,115 @@ export function navigateMonth(
   return { year: d.getFullYear(), month: d.getMonth() };
 }
 
+// ─── View mode ──────────────────────────────────────────────────
+
+export type CalendarViewMode = "month" | "week";
+
+// ─── Week grid ──────────────────────────────────────────────────
+
+export interface WeekGrid {
+  days: CalendarDay[]; // 7 items (Sun–Sat)
+  label: string; // "Feb 23 – Mar 1, 2026"
+  gridStart: string;
+  gridEnd: string;
+}
+
+/** Build a 7-day grid for the week containing the given date (Sunday start). */
+export function buildWeekGrid(year: number, month: number, day: number): WeekGrid {
+  const todayKey = toDateKey(new Date());
+  const ref = new Date(year, month, day);
+  const sundayOffset = ref.getDay(); // 0 = Sunday
+  const sunday = new Date(year, month, day - sundayOffset);
+
+  const days: CalendarDay[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(sunday);
+    d.setDate(sunday.getDate() + i);
+    const dateKey = toDateKey(d);
+    days.push({
+      date: d,
+      dateKey,
+      dayOfMonth: d.getDate(),
+      isCurrentMonth: d.getMonth() === month && d.getFullYear() === year,
+      isToday: dateKey === todayKey,
+    });
+  }
+
+  const start = days[0].date;
+  const end = days[6].date;
+  const fmt = (d: Date) =>
+    d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  const label =
+    start.getFullYear() !== end.getFullYear()
+      ? `${fmt(start)}, ${start.getFullYear()} – ${fmt(end)}, ${end.getFullYear()}`
+      : start.getMonth() !== end.getMonth()
+        ? `${fmt(start)} – ${fmt(end)}, ${end.getFullYear()}`
+        : `${start.toLocaleDateString("en-US", { month: "short" })} ${start.getDate()} – ${end.getDate()}, ${end.getFullYear()}`;
+
+  return {
+    days,
+    label,
+    gridStart: days[0].dateKey + "T00:00:00",
+    gridEnd: days[6].dateKey + "T23:59:59",
+  };
+}
+
+/** Navigate by ±1 week. */
+export function navigateWeek(
+  year: number,
+  month: number,
+  day: number,
+  delta: number
+): { year: number; month: number; day: number } {
+  const d = new Date(year, month, day + delta * 7);
+  return { year: d.getFullYear(), month: d.getMonth(), day: d.getDate() };
+}
+
+// ─── Event helpers ──────────────────────────────────────────────
+
+/** Split events into all-day and timed, sorted by start time. */
+export function sortEventsForCell(
+  events: CalendarEvent[]
+): { allDay: CalendarEvent[]; timed: CalendarEvent[] } {
+  const allDay: CalendarEvent[] = [];
+  const timed: CalendarEvent[] = [];
+  for (const e of events) {
+    if (e.start.includes("T")) {
+      timed.push(e);
+    } else {
+      allDay.push(e);
+    }
+  }
+  timed.sort((a, b) => a.start.localeCompare(b.start));
+  return { allDay, timed };
+}
+
+/** Get top/height percentages for positioning an event in the week time grid. */
+export function getEventTopAndHeight(
+  event: CalendarEvent,
+  startHour: number,
+  endHour: number
+): { topPercent: number; heightPercent: number } {
+  const totalMinutes = (endHour - startHour) * 60;
+  const s = new Date(event.start);
+  const e = new Date(event.end);
+
+  let startMin = s.getHours() * 60 + s.getMinutes() - startHour * 60;
+  let endMin = e.getHours() * 60 + e.getMinutes() - startHour * 60;
+
+  startMin = Math.max(0, Math.min(startMin, totalMinutes));
+  endMin = Math.max(0, Math.min(endMin, totalMinutes));
+
+  const duration = Math.max(endMin - startMin, 15); // minimum 15min visual height
+
+  return {
+    topPercent: (startMin / totalMinutes) * 100,
+    heightPercent: (duration / totalMinutes) * 100,
+  };
+}
+
+// ─── Internal ───────────────────────────────────────────────────
+
 function toDateKey(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -52,6 +52,17 @@ export function formatDateShort(dateKey: string): string {
   });
 }
 
+/** Format ISO timestamp to compact time: "9 AM" or "9:30 AM" */
+export function formatTimeShort(isoString: string): string {
+  if (!isoString.includes("T")) return "All day";
+  const d = new Date(isoString);
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const period = h >= 12 ? "PM" : "AM";
+  const h12 = h % 12 || 12;
+  return m === 0 ? `${h12} ${period}` : `${h12}:${String(m).padStart(2, "0")} ${period}`;
+}
+
 /** Format YYYY-MM-DD as "Saturday, February 28, 2026" */
 export function formatDateLong(dateKey: string): string {
   const date = new Date(dateKey + "T12:00:00");


### PR DESCRIPTION
## Summary
- **Week view**: Full time-grid with hour slots (7 AM–10 PM), absolutely-positioned event blocks, all-day events row, and red current-time indicator line
- **Month view overhaul**: Replaced dots with event chips showing event summary text — responsive mobile dots / desktop chips with "+N more" overflow
- **View toggle**: Month/Week segmented control in the navigation header, with navigation adapting (±1 month vs ±1 week)
- **Utilities**: `buildWeekGrid`, `navigateWeek`, `sortEventsForCell`, `getEventTopAndHeight`, `formatTimeShort`

## Files changed (6)
| File | Change |
|------|--------|
| `src/lib/utils/calendar.ts` | Week grid utilities, event sorting, percentage positioning |
| `src/lib/utils/dates.ts` | `formatTimeShort` — compact time labels ("9 AM", "9:30 AM") |
| `src/components/calendar/MonthGrid.tsx` | Event chips with text instead of dots |
| `src/components/calendar/WeekView.tsx` | **New** — full week time-grid component |
| `src/components/calendar/MonthNavigation.tsx` | View toggle segmented control |
| `src/app/calendar/page.tsx` | Dual-view orchestrator with adaptive SWR/navigation |

## Test plan
- [ ] Month view: event chips visible with summary text, "+N more" overflow works
- [ ] Week view: time grid renders with positioned event blocks and all-day row
- [ ] Current time red indicator line shows on today's column in week view
- [ ] View toggle: Month ↔ Week switches correctly, navigation adapts
- [ ] "Today" button works in both views
- [ ] SWR refetches on view/navigation change (check network tab)
- [ ] Mobile: dots on month view, week view scrollable
- [ ] Guest: sign-in prompt (no regression)
- [ ] Dashboard UpcomingEvents widget still works
- [ ] Build compiles with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)