### PR TITLE
feat: shared hooks, utils, and UI primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to see the app.
+
+### Shared utilities
+
+A small set of reusable hooks and helpers backs the modules above:
+
+- `src/hooks/` — `useDebounce`, `useLocalStorage`, `useMediaQuery`, `usePrevious`, `useTimer`, `useToggle`
+- `src/lib/utils/` — `dates`, `calculations`, `format`, `group`, `relative-time`, `calendar`
+- `src/components/ui/` — `Button`, `Card`, `Modal`, `Badge`
+
+Each is intentionally framework-thin so the next phase can pull them in without leaning on a wider component library.

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,23 @@
+interface BadgeProps {
+  children: React.ReactNode;
+  variant?: "default" | "success" | "warning" | "danger" | "info";
+  className?: string;
+}
+
+const VARIANTS: Record<NonNullable<BadgeProps["variant"]>, string> = {
+  default: "bg-surface border-border text-text",
+  success: "bg-emerald-500/15 border-emerald-500/30 text-emerald-300",
+  warning: "bg-amber-500/15 border-amber-500/30 text-amber-300",
+  danger: "bg-rose-500/15 border-rose-500/30 text-rose-300",
+  info: "bg-sky-500/15 border-sky-500/30 text-sky-300",
+};
+
+export function Badge({ children, variant = "default", className = "" }: BadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-xs font-medium ${VARIANTS[variant]} ${className}`}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Subscribe to a CSS media query. Returns false on the server and
+ * during the first client render to avoid hydration mismatches; flips
+ * to the real value after mount.
+ *
+ * @example
+ * const isDesktop = useMediaQuery("(min-width: 1024px)");
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,20 @@
+import { useRef, useEffect } from "react";
+
+/**
+ * Returns the previous value of `value` across renders. First render
+ * returns undefined. Handy for diff-aware effects: "fire when the
+ * selected date *changes*, not on mount".
+ *
+ * @example
+ * const prevDate = usePrevious(selectedDate);
+ * useEffect(() => {
+ *   if (prevDate && prevDate !== selectedDate) refetch();
+ * }, [selectedDate, prevDate]);
+ */
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,20 @@
+import { useState, useCallback } from "react";
+
+/**
+ * Boolean state with stable on/off/toggle callbacks. Saves the
+ * sprinkle of `useCallback(() => setX(v => !v), [])` boilerplate
+ * we keep writing for modals, drawers, and disclosure widgets.
+ *
+ * @example
+ * const [isOpen, { toggle, off }] = useToggle(false);
+ */
+export function useToggle(initial: boolean = false): [
+  boolean,
+  { toggle: () => void; on: () => void; off: () => void; set: (v: boolean) => void }
+] {
+  const [value, setValue] = useState(initial);
+  const toggle = useCallback(() => setValue((v) => !v), []);
+  const on = useCallback(() => setValue(true), []);
+  const off = useCallback(() => setValue(false), []);
+  return [value, { toggle, on, off, set: setValue }];
+}

--- a/src/lib/utils/calculations.ts
+++ b/src/lib/utils/calculations.ts
@@ -46,3 +46,27 @@ export function pct(consumed: number, target: number): number {
 export function remaining(target: number, consumed: number): number {
   return Math.max(0, target - consumed);
 }
+
+/**
+ * Percent change between two values, e.g. ((current - previous) / previous) * 100.
+ * Returns null when previous is 0 or nullish, since the answer is undefined.
+ */
+export function percentChange(
+  current: number,
+  previous: number | null | undefined
+): number | null {
+  if (previous == null || previous === 0) return null;
+  return ((current - previous) / previous) * 100;
+}
+
+/** Sum a numeric array, treating null/undefined as zero. */
+export function sum(values: (number | null | undefined)[]): number {
+  return values.reduce<number>((total, v) => total + (v ?? 0), 0);
+}
+
+/** Average of a numeric array, ignoring null/undefined. Returns null when empty. */
+export function average(values: (number | null | undefined)[]): number | null {
+  const present = values.filter((v): v is number => v != null);
+  if (present.length === 0) return null;
+  return present.reduce((a, b) => a + b, 0) / present.length;
+}

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -73,3 +73,25 @@ export function formatDateLong(dateKey: string): string {
     year: "numeric",
   });
 }
+
+/** True when the YYYY-MM-DD key matches today (local time). */
+export function isToday(dateKey: string): boolean {
+  return dateKey === today();
+}
+
+/** True when the YYYY-MM-DD key is exactly one day before today. */
+export function isYesterday(dateKey: string): boolean {
+  const y = new Date();
+  y.setDate(y.getDate() - 1);
+  return dateKey === formatDateKey(y);
+}
+
+/**
+ * Render a date key with the friendly relative label where it helps:
+ * "Today", "Yesterday", "Mon, Feb 28".
+ */
+export function formatDateFriendly(dateKey: string): string {
+  if (isToday(dateKey)) return "Today";
+  if (isYesterday(dateKey)) return "Yesterday";
+  return formatDateShort(dateKey);
+}

--- a/src/lib/utils/group.ts
+++ b/src/lib/utils/group.ts
@@ -1,0 +1,29 @@
+/**
+ * Group an array of records by a key derived from each item.
+ * Result preserves insertion order of the first key occurrence.
+ *
+ * @example
+ * groupBy(blocks, (b) => b.date)
+ * // { "2026-05-15": [...], "2026-05-14": [...] }
+ */
+export function groupBy<T, K extends string | number>(
+  items: T[],
+  getKey: (item: T) => K
+): Record<K, T[]> {
+  const out = {} as Record<K, T[]>;
+  for (const item of items) {
+    const key = getKey(item);
+    if (!out[key]) out[key] = [];
+    out[key].push(item);
+  }
+  return out;
+}
+
+/**
+ * Sort an array of YYYY-MM-DD keys descending (most recent first) without
+ * mutating the input. Convenience around the obvious string sort + reverse
+ * because every consumer keeps reinventing it.
+ */
+export function sortDateKeysDesc(keys: string[]): string[] {
+  return [...keys].sort((a, b) => b.localeCompare(a));
+}

--- a/src/lib/utils/relative-time.ts
+++ b/src/lib/utils/relative-time.ts
@@ -1,0 +1,26 @@
+/**
+ * Format a Date or ISO timestamp as a human-friendly relative time:
+ * "just now", "2m ago", "3h ago", "yesterday", "Mar 12".
+ *
+ * Anything older than 7 days falls back to a short date so the UI doesn't
+ * end up saying "47d ago" for an event from two months back.
+ */
+export function formatRelativeTime(input: Date | string, now: Date = new Date()): string {
+  const date = typeof input === "string" ? new Date(input) : input;
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.round(diffMs / 1000);
+
+  if (diffSec < 45) return "just now";
+
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay === 1) return "yesterday";
+  if (diffDay < 7) return `${diffDay}d ago`;
+
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,3 +131,12 @@ export interface NavItem {
   href: string;
   icon: string;
 }
+
+// === Time ranges ===
+/** Time window used by metrics, retros, and dashboard filters. */
+export type Period = "day" | "week" | "month" | "quarter" | "year";
+
+export interface DateRange {
+  start: string; // YYYY-MM-DD inclusive
+  end: string;   // YYYY-MM-DD inclusive
+}


### PR DESCRIPTION
## Summary

A week's worth of small, additive utilities and one UI primitive that don't change any existing behavior. Every file is either brand new or appends to an existing module — nothing is replaced or refactored.

### What's included

**Hooks** (`src/hooks/`)
- `useMediaQuery` — SSR-safe responsive breakpoints
- `usePrevious` — track previous value across renders for change-aware effects
- `useToggle` — boolean state with stable on/off/toggle/set callbacks

**Utilities** (`src/lib/utils/`)
- `relative-time.ts` → `formatRelativeTime` ("just now", "2m ago", "yesterday", "Mar 12")
- `group.ts` → `groupBy`, `sortDateKeysDesc`
- `dates.ts` (additive) → `isToday`, `isYesterday`, `formatDateFriendly`
- `calculations.ts` (additive) → `percentChange`, `sum`, `average`

**UI** (`src/components/ui/`)
- `Badge` — pill component with `default / success / warning / danger / info` variants

**Types** (`src/types/index.ts`)
- `Period` (`day / week / month / quarter / year`) and `DateRange` — shared so the upcoming metrics-review and weekly-retro modules use the same vocabulary

**Docs**
- README: shared-utils section listing the above so newcomers don't have to grep

### Per-day commit breakdown

- **Mon May 11** — `formatRelativeTime`, `useMediaQuery`, `Period/DateRange`, `useToggle`
- **Wed May 13** — `isToday/isYesterday/formatDateFriendly`, `usePrevious`, `Badge`, `percentChange/sum/average`
- **Fri May 15** — `groupBy/sortDateKeysDesc`, README shared-utils section

## Test plan

- [ ] `npm run lint` is clean
- [ ] `npm run build` succeeds (no broken imports against existing modules)
- [ ] Verify `useMediaQuery` returns `false` on first render (SSR safety)
- [ ] Visual check on `<Badge variant=...>` against existing surface/border palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)